### PR TITLE
Removed unnecessary text

### DIFF
--- a/js/auth/simple-login.js
+++ b/js/auth/simple-login.js
@@ -31,7 +31,7 @@ define( [ 'jquery', 'core/theme-app', 'core/modules/authentication' ], function(
 			$user_info.html( 'Logged in as <a href="#user-page">'+ current_user.login +'</a> <button type="button" class="btn btn-danger" id="logout">Log out</button>');
 		} else { 
 			//User not logged in : display the login button :
-			$user_info.html( 'No user connected <button type="button" class="btn btn-info" id="login">Log in</button>' );
+			$user_info.html( '<button type="button" class="btn btn-info" id="login">Log in</button>' );
 		}
 		
 	};


### PR DESCRIPTION
Button already tells users they aren't already logged in, button changes to 'Log Out' when you are logged in, thus making this bit of incorrect language look messy.
