### PR TITLE
WP basic allows

### DIFF
--- a/php/allow-blockquotes.php
+++ b/php/allow-blockquotes.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_bloq_tag', 10, 2);
+function wpak_allow_bloq_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<blockquote>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-bold.php
+++ b/php/allow-bold.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_bold_tag', 10, 2);
+function wpak_allow_bold_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<strong>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-headers.php
+++ b/php/allow-headers.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_htag_tag', 10, 2);
+function wpak_allow_htag_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<h1>,<h2>,<h3>,<h4>,<h5>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-iframes.php
+++ b/php/allow-iframes.php
@@ -1,0 +1,14 @@
+<?php
+/*
+ * Applies to:  since WP-AppKit 0.1
+ * Goal:        By default, iframes are stripped from post content when send to WP-AppKit apps.
+ *              It removes iframes inserted by WordPress through the oEmbed mechanism like videos (https://codex.wordpress.org/Embeds).
+ *              We'd like to let iframes pass to the app to display video embeds in apps.
+ * Usage:       in the app's theme PHP folder or a separate plugin.
+*/
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_iframe_tag', 10, 2);
+function wpak_allow_iframe_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<iframe>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-img.php
+++ b/php/allow-img.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_img_tag', 10, 2);
+function wpak_allow_img_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<img>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-italics.php
+++ b/php/allow-italics.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_ita_tag', 10, 2);
+function wpak_allow_ita_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<em>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-linesthru.php
+++ b/php/allow-linesthru.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_del_tag', 10, 2);
+function wpak_allow_del_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<del>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-links.php
+++ b/php/allow-links.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_link_tag', 10, 2);
+function wpak_allow_link_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<a>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-lists.php
+++ b/php/allow-lists.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_lists_tag', 10, 2);
+function wpak_allow_lists_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<ul>,<li>,<ol>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-par.php
+++ b/php/allow-par.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_par_tag', 10, 2);
+function wpak_allow_par_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<p>';
+  return $allowed_tags;
+}
+?>

--- a/php/allow-unlines-colors-span.php
+++ b/php/allow-unlines-colors-span.php
@@ -1,0 +1,8 @@
+<?php
+
+add_filter( 'wpak_post_content_allowed_tags', 'wpak_allow_span_tag', 10, 2);
+function wpak_allow_span_tag( $allowed_tags, $post ) {
+  $allowed_tags .= '<span>';
+  return $allowed_tags;
+}
+?>


### PR DESCRIPTION
These php plugins allow for the passing of the styling tags used by the
default WP tinyMCE editor.

White listing is good.
But
Should white list WP default style for WP apps, the fix should be modular so individual tags can be easily removed from the white-list.
This fixes that.
